### PR TITLE
Fix suppliers resolvers for count field

### DIFF
--- a/server/resolvers/queries/suppliers.js
+++ b/server/resolvers/queries/suppliers.js
@@ -1,6 +1,10 @@
 const Suppliers = require('../../models/supplier.model');
 const { connectionFromArray } = require('graphql-relay');
 
-const suppliers = (obj, args) => Suppliers.find({}).then(res => connectionFromArray(res, args));
+const suppliers = async (obj, args) => {
+  const suppliersDB = await Suppliers.find({}).then(res => connectionFromArray(res, args));
+
+  return Object.assign(suppliersDB, { count: suppliersDB.edges.length || 0 });
+}
 
 module.exports = suppliers;


### PR DESCRIPTION
This fix is to resolve the `count` field that is not covered by `connectionFromArray`.